### PR TITLE
Use tempfile.mkstemp instead of hardcoded temp.txt for concurrency safety

### DIFF
--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -1,13 +1,10 @@
-from guardrails import Guard
+import concurrent.futures
+
+from guardrails import Guard, OnFailAction
 from validator import SecretsPresent
 import pytest
 
 
-# Instantiate the validator
-validator = SecretsPresent(on_fail="exception")
-
-
-# Test happy path
 @pytest.mark.parametrize(
     "value",
     [
@@ -26,13 +23,11 @@ validator = SecretsPresent(on_fail="exception")
 )
 def test_happy_path(value):
     """Test happy path."""
-    guard = Guard.from_string(validators=[validator])
-    response = guard.parse(value)
-    print("Happy path response", response)
+    guard = Guard().use(SecretsPresent(on_fail=OnFailAction.EXCEPTION))
+    response = guard.validate(value)
     assert response.validation_passed is True
 
 
-# Test fail path
 @pytest.mark.parametrize(
     "value",
     [
@@ -53,7 +48,29 @@ def test_happy_path(value):
 )
 def test_fail_path(value):
     """Test fail path."""
-    guard = Guard.from_string(validators=[validator])
+    guard = Guard().use(SecretsPresent(on_fail=OnFailAction.EXCEPTION))
     with pytest.raises(Exception):
-        response = guard.parse(value)
-        print("Fail path response", response)
+        guard.validate(value)
+
+
+def test_concurrent_validation():
+    """Multiple SecretsPresent instances should not interfere with each other."""
+
+    def validate(text):
+        guard = Guard().use(SecretsPresent(on_fail=OnFailAction.NOOP))
+        return guard.validate(text)
+
+    inputs = [
+        "no secrets here\n",
+        "also clean text\n",
+        "nothing to see\n",
+        "just regular code\n",
+    ]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(validate, text) for text in inputs]
+        results = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+    assert len(results) == 4
+    for result in results:
+        assert result.validation_passed is True

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -1,6 +1,7 @@
+import asyncio
 import concurrent.futures
 
-from guardrails import Guard, OnFailAction
+from guardrails import AsyncGuard, Guard, OnFailAction
 from validator import SecretsPresent
 import pytest
 
@@ -60,17 +61,49 @@ def test_concurrent_validation():
         guard = Guard().use(SecretsPresent(on_fail=OnFailAction.NOOP))
         return guard.validate(text)
 
-    inputs = [
+    clean_inputs = [
         "no secrets here\n",
         "also clean text\n",
         "nothing to see\n",
-        "just regular code\n",
     ]
+    secret_inputs = [
+        'api_key = "sk_test_4eC39HqLyjWDarjtT1zdp7dc"\n',  # gitleaks:allow
+    ]
+    inputs = clean_inputs + secret_inputs
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
-        futures = [pool.submit(validate, text) for text in inputs]
-        results = [f.result() for f in concurrent.futures.as_completed(futures)]
+        futures = {pool.submit(validate, text): text for text in inputs}
+        results = {text: f.result() for f, text in futures.items()}
 
     assert len(results) == 4
-    for result in results:
-        assert result.validation_passed is True
+    for text in clean_inputs:
+        assert results[text].validation_passed is True
+    for text in secret_inputs:
+        assert results[text].validation_passed is False
+
+
+@pytest.mark.asyncio
+async def test_async_concurrent_validation():
+    """Multiple async SecretsPresent validations should not interfere with each other."""
+
+    async def validate(text):
+        guard = AsyncGuard().use(SecretsPresent(on_fail=OnFailAction.NOOP))
+        return await guard.validate(text)
+
+    clean_inputs = [
+        "no secrets here\n",
+        "also clean text\n",
+        "nothing to see\n",
+    ]
+    secret_inputs = [
+        'api_key = "sk_test_4eC39HqLyjWDarjtT1zdp7dc"\n',  # gitleaks:allow
+    ]
+    inputs = clean_inputs + secret_inputs
+
+    results = await asyncio.gather(*[validate(text) for text in inputs])
+
+    assert len(results) == 4
+    for i, text in enumerate(clean_inputs):
+        assert results[i].validation_passed is True
+    for i, text in enumerate(secret_inputs, start=len(clean_inputs)):
+        assert results[i].validation_passed is False

--- a/validator/main.py
+++ b/validator/main.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import warnings
 from typing import Any, Callable, Dict, List, Tuple, Union
 
@@ -53,7 +54,6 @@ class SecretsPresent(Validator):
     def __init__(self, on_fail: Union[Callable[..., Any], None] = None, **kwargs):
         super().__init__(on_fail, **kwargs)
 
-        self.temp_file_name = "temp.txt"
         self.mask = "********"
 
     def get_unique_secrets(self, value: str) -> Tuple[Dict[str, Any], List[str]]:
@@ -67,68 +67,46 @@ class SecretsPresent(Validator):
                 line numbers.
             lines (List[str]): The lines of the generated code snippet.
         """
+        # Use a unique temp file per call to avoid race conditions when
+        # multiple SecretsPresent instances run concurrently.
+        fd, temp_path = tempfile.mkstemp(suffix=".txt", prefix="guardrails_secrets_")
         try:
-            # Write each line of value to a new file
-            with open(self.temp_file_name, "w") as f:
-                f.writelines(value)
-        except Exception as e:
-            raise OSError(
-                "Problems creating or deleting the temporary file. "
-                "Please check the permissions of the current directory."
-            ) from e
+            with os.fdopen(fd, "w") as f:
+                f.write(value)
 
-        try:
-            # Create a new secrets collection
-            from detect_secrets import settings
-            from detect_secrets.core.secrets_collection import SecretsCollection
+            try:
+                from detect_secrets import settings
+                from detect_secrets.core.secrets_collection import SecretsCollection
 
-            secrets = SecretsCollection()
+                secrets = SecretsCollection()
 
-            # Scan the file for secrets
-            with settings.default_settings():
-                secrets.scan_file(self.temp_file_name)
-        except ImportError:
-            raise ValueError(
-                "You must install detect-secrets in order to "
-                "use the DetectSecrets validator."
-            )
-        except Exception as e:
-            raise RuntimeError(
-                "Problems with creating a SecretsCollection or "
-                "scanning the file for secrets."
-            ) from e
+                with settings.default_settings():
+                    secrets.scan_file(temp_path)
+            except ImportError:
+                raise ValueError(
+                    "You must install detect-secrets in order to "
+                    "use the DetectSecrets validator."
+                )
 
-        # Get unique secrets from these secrets
-        unique_secrets = {}
-        for secret in secrets:
-            _, potential_secret = secret
-            actual_secret = potential_secret.secret_value
-            line_number = potential_secret.line_number
-            if actual_secret not in unique_secrets:
-                unique_secrets[actual_secret] = [line_number]
-            else:
-                # if secret already exists, avoid duplicate line numbers
-                if line_number not in unique_secrets[actual_secret]:
-                    unique_secrets[actual_secret].append(line_number)
+            # Get unique secrets from these secrets
+            unique_secrets = {}
+            for secret in secrets:
+                _, potential_secret = secret
+                actual_secret = potential_secret.secret_value
+                line_number = potential_secret.line_number
+                if actual_secret not in unique_secrets:
+                    unique_secrets[actual_secret] = [line_number]
+                else:
+                    if line_number not in unique_secrets[actual_secret]:
+                        unique_secrets[actual_secret].append(line_number)
 
-        try:
-            # File no longer needed, read the lines from the file
-            with open(self.temp_file_name, "r") as f:
+            with open(temp_path, "r") as f:
                 lines = f.readlines()
-        except Exception as e:
-            raise OSError(
-                "Problems reading the temporary file. "
-                "Please check the permissions of the current directory."
-            ) from e
+        finally:
+            # Always clean up, even if an exception occurred above.
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
 
-        try:
-            # Delete the file
-            os.remove(self.temp_file_name)
-        except Exception as e:
-            raise OSError(
-                "Problems deleting the temporary file. "
-                "Please check the permissions of the current directory."
-            ) from e
         return unique_secrets, lines
 
     def get_modified_value(


### PR DESCRIPTION
Fixes #9

## What changed

`get_unique_secrets()` was writing to a hardcoded `temp.txt` in the current working directory. This breaks when multiple `SecretsPresent` instances run concurrently -- one instance deletes the file while another is still reading it, causing `OSError: Problems reading the temporary file`.

This is the root cause of failures when using `SecretsPresent` inside frameworks that run validators in parallel (like MLflow's `evaluate()`).

## Changes

**`validator/main.py`**
- Replace `self.temp_file_name = "temp.txt"` with `tempfile.mkstemp()` which creates a unique file per call in the system temp directory
- Wrap the whole write/scan/read/delete sequence in `try/finally` so the temp file is always cleaned up, even on exceptions
- Removed the scattered try/except blocks that obscured the real error with generic "check permissions" messages

**`test/test_validator.py`**
- Update tests to use current guardrails 0.9.0 API (`Guard().use()` + `guard.validate()` instead of removed `Guard.from_string` + `guard.parse`)
- Add `test_concurrent_validation` that runs 4 validations in parallel threads to verify no race conditions

## Testing

All 5 tests pass (4 existing + 1 new concurrency test):

```
test/test_validator.py::test_happy_path[...] PASSED
test/test_validator.py::test_happy_path[...] PASSED
test/test_validator.py::test_fail_path[...] PASSED
test/test_validator.py::test_fail_path[...] PASSED
test/test_validator.py::test_concurrent_validation PASSED
```

Verified no temp files leak after the test run.

Found while integrating Guardrails AI validators into MLflow's evaluation framework ([mlflow/mlflow#20038](https://github.com/mlflow/mlflow/pull/20038)).