### PR TITLE
Fix concurrent test inputs and pytest-asyncio config

### DIFF
--- a/.github/workflows/pr_qc.yml
+++ b/.github/workflows/pr_qc.yml
@@ -2,7 +2,7 @@ name: Pull Request Quality Checks
 on:
   pull_request:
     types: [ opened, synchronize ]
-    branches: [ main ]
+    branches: [ main, v0.0.1 ]
 jobs:
   run-qa:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ addopts = "-rP"
 testpaths = [
     "test"
 ]
+asyncio_mode = "auto"
 
 [tool.pyright]
 include = ["validator"]

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -61,13 +61,15 @@ def test_concurrent_validation():
         guard = Guard().use(SecretsPresent(on_fail=OnFailAction.NOOP))
         return guard.validate(text)
 
+    # detect-secrets needs multi-line code context to reliably trigger its
+    # heuristics, so use realistic snippets instead of bare one-liners.
     clean_inputs = [
-        "no secrets here\n",
-        "also clean text\n",
-        "nothing to see\n",
+        "def greet():\n    print('hello world')\n",
+        "import os\npath = os.getcwd()\n",
+        "x = 42\ny = x + 1\n",
     ]
     secret_inputs = [
-        'api_key = "sk_test_4eC39HqLyjWDarjtT1zdp7dc"\n',  # gitleaks:allow
+        'def connect():\n    api_key = "sk_test_4eC39HqLyjWDarjtT1zdp7dc"\n    return api_key\n',  # gitleaks:allow
     ]
     inputs = clean_inputs + secret_inputs
 
@@ -91,12 +93,12 @@ async def test_async_concurrent_validation():
         return await guard.validate(text)
 
     clean_inputs = [
-        "no secrets here\n",
-        "also clean text\n",
-        "nothing to see\n",
+        "def greet():\n    print('hello world')\n",
+        "import os\npath = os.getcwd()\n",
+        "x = 42\ny = x + 1\n",
     ]
     secret_inputs = [
-        'api_key = "sk_test_4eC39HqLyjWDarjtT1zdp7dc"\n',  # gitleaks:allow
+        'def connect():\n    api_key = "sk_test_4eC39HqLyjWDarjtT1zdp7dc"\n    return api_key\n',  # gitleaks:allow
     ]
     inputs = clean_inputs + secret_inputs
 


### PR DESCRIPTION
## Summary

Follows up on #10 to fix the two CI failures in `run-qa`.

## Changes

- Use multi-line code snippets in `test_concurrent_validation` and `test_async_concurrent_validation` so `detect-secrets` reliably triggers its heuristics. The previous one-liner inputs (`api_key = "sk_test_..."`\n) were too minimal for `detect-secrets` to flag.
- Add `asyncio_mode = "auto"` to `[tool.pytest.ini_options]` so `@pytest.mark.asyncio` is recognized by `pytest-asyncio`.
- Extend CI workflow to also run on `v0.0.1` branch PRs.

## Testing

All 6 tests pass locally:

```
test_happy_path[...] PASSED
test_happy_path[...] PASSED
test_fail_path[...] PASSED
test_fail_path[...] PASSED
test_concurrent_validation PASSED
test_async_concurrent_validation PASSED
======================== 6 passed in 3.68s =========================
```